### PR TITLE
Initial support for ALPN

### DIFF
--- a/client/BufferedSocket.cpp
+++ b/client/BufferedSocket.cpp
@@ -166,7 +166,7 @@ void BufferedSocket::connect(const string& aAddress, uint16_t aPort, bool secure
 void BufferedSocket::connect(const string& aAddress, uint16_t aPort, uint16_t localPort, NatRoles natRole, bool secure, bool allowUntrusted, bool proxy, const string& expKP /*= Util::emptyString*/)
 {
 	dcdebug("BufferedSocket::connect() %p\n", (void*)this);
-	unique_ptr<Socket> s(secure ? new SSLSocket(natRole == NAT_SERVER ? CryptoManager::SSL_SERVER : CryptoManager::SSL_CLIENT, allowUntrusted, expKP) : new Socket(/*Socket::TYPE_TCP*/));
+	unique_ptr<Socket> s(secure ? new SSLSocket(natRole == NAT_SERVER ? CryptoManager::SSL_SERVER : CryptoManager::SSL_CLIENT_ALPN, allowUntrusted, expKP) : new Socket(/*Socket::TYPE_TCP*/));
 	s->create(); // в AirDC++ нет такой херни... разобраться
 	
 	setSocket(move(s));

--- a/client/CryptoManager.cpp
+++ b/client/CryptoManager.cpp
@@ -41,6 +41,10 @@ bool CryptoManager::certsLoaded = false;
 ByteVector CryptoManager::keyprint;
 static CriticalSection g_cs;
 
+unsigned char alpn_protos[] = {
+	3, 'a', 'd', 'c',
+	4, 'n', 'm', 'd', 'c',
+};
 
 CryptoManager::CryptoManager()
 	:
@@ -56,11 +60,12 @@ CryptoManager::CryptoManager()
 	SSL_load_error_strings();
 	
 	clientContext.reset(SSL_CTX_new(SSLv23_client_method()));
+	clientALPNContext.reset(SSL_CTX_new(SSLv23_client_method()));
 	serverContext.reset(SSL_CTX_new(SSLv23_server_method()));
 	
 	idxVerifyData = SSL_get_ex_new_index(0, idxVerifyDataName, NULL, NULL, NULL);
 	
-	if (clientContext && serverContext)
+	if (clientContext && clientALPNContext && serverContext)
 	{
 		// Check that openssl rng has been seeded with enough data
 		sslRandCheck();
@@ -72,9 +77,12 @@ CryptoManager::CryptoManager()
 		SSL_CTX_set_options(clientContext, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
 		SSL_CTX_set_cipher_list(clientContext, ciphersuites);
 		SSL_CTX_set1_curves_list(clientContext, "P-256");
+		SSL_CTX_set_options(clientALPNContext, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
+		SSL_CTX_set_cipher_list(clientALPNContext, ciphersuites);
+		SSL_CTX_set1_curves_list(clientALPNContext, "P-256");
 		SSL_CTX_set_options(serverContext, SSL_OP_SINGLE_DH_USE | SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
-		SSL_CTX_set_cipher_list(clientContext, ciphersuites);
-		SSL_CTX_set1_curves_list(clientContext, "P-256");
+		SSL_CTX_set_cipher_list(serverContext, ciphersuites);
+		SSL_CTX_set1_curves_list(serverContext, "P-256");
 		
 		EC_KEY* tmp_ecdh;
 		if ((tmp_ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1)) != NULL)
@@ -89,7 +97,10 @@ CryptoManager::CryptoManager()
 		SSL_CTX_set_tmp_rsa_callback(serverContext, CryptoManager::tmp_rsa_cb);
 		
 		SSL_CTX_set_verify(clientContext, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, verify_callback);
+		SSL_CTX_set_verify(clientALPNContext, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, verify_callback);
 		SSL_CTX_set_verify(serverContext, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, verify_callback);
+
+		SSL_CTX_set_alpn_protos(clientALPNContext, alpn_protos, sizeof(alpn_protos));
 	}
 }
 void CryptoManager::initTmpKeyMaps()
@@ -141,6 +152,7 @@ CryptoManager::~CryptoManager()
 	ERR_remove_thread_state(NULL);
 	
 	clientContext.reset();
+	clientALPNContext.reset();
 	serverContext.reset();
 	
 	freeTmpKeyMaps();
@@ -585,7 +597,7 @@ void CryptoManager::generateCertificate()
 
 void CryptoManager::loadCertificates() noexcept
 {
-	if (!BOOLSETTING(USE_TLS) || !clientContext || !serverContext)
+	if (!BOOLSETTING(USE_TLS) || !clientContext || !clientALPNContext || !serverContext)
 		return;
 		
 	const string& cert = SETTING(TLS_CERTIFICATE_FILE);
@@ -617,6 +629,7 @@ void CryptoManager::loadCertificates() noexcept
 	
 	if (
 	    SSL_CTX_use_certificate_file(serverContext, cert.c_str(), SSL_FILETYPE_PEM) != SSL_SUCCESS ||
+		SSL_CTX_use_certificate_file(clientALPNContext, cert.c_str(), SSL_FILETYPE_PEM) != SSL_SUCCESS ||
 	    SSL_CTX_use_certificate_file(clientContext, cert.c_str(), SSL_FILETYPE_PEM) != SSL_SUCCESS
 	)
 	{
@@ -626,6 +639,7 @@ void CryptoManager::loadCertificates() noexcept
 	
 	if (
 	    SSL_CTX_use_PrivateKey_file(serverContext, key.c_str(), SSL_FILETYPE_PEM) != SSL_SUCCESS ||
+		SSL_CTX_use_PrivateKey_file(clientALPNContext, key.c_str(), SSL_FILETYPE_PEM) != SSL_SUCCESS ||
 	    SSL_CTX_use_PrivateKey_file(clientContext, key.c_str(), SSL_FILETYPE_PEM) != SSL_SUCCESS
 	)
 	{
@@ -641,6 +655,7 @@ void CryptoManager::loadCertificates() noexcept
 	{
 		if (
 		    SSL_CTX_load_verify_locations(clientContext, i.c_str(), NULL) != SSL_SUCCESS ||
+			SSL_CTX_load_verify_locations(clientALPNContext, i.c_str(), NULL) != SSL_SUCCESS ||
 		    SSL_CTX_load_verify_locations(serverContext, i.c_str(), NULL) != SSL_SUCCESS
 		)
 		{
@@ -762,6 +777,8 @@ SSL_CTX* CryptoManager::getSSLContext(SSLContext wanted)
 	{
 		case SSL_CLIENT:
 			return clientContext;
+		case SSL_CLIENT_ALPN:
+			return clientALPNContext;
 		case SSL_SERVER:
 			return serverContext;
 		default:

--- a/client/CryptoManager.h
+++ b/client/CryptoManager.h
@@ -108,6 +108,7 @@ class CryptoManager : public Singleton<CryptoManager>
 		enum SSLContext
 		{
 			SSL_CLIENT,
+			SSL_CLIENT_ALPN,
 			SSL_SERVER
 		};
 		
@@ -150,6 +151,7 @@ class CryptoManager : public Singleton<CryptoManager>
 		virtual ~CryptoManager();
 		
 		ssl::SSL_CTX clientContext;
+		ssl::SSL_CTX clientALPNContext;
 		ssl::SSL_CTX serverContext;
 		
 		void sslRandCheck();

--- a/client/SSLSocket.cpp
+++ b/client/SSLSocket.cpp
@@ -79,6 +79,21 @@ bool SSLSocket::waitConnected(uint64_t millis)
 		if (ret == 1)
 		{
 			dcdebug("Connected to SSL server using %s as %s\n", SSL_get_cipher(ssl), ssl->server ? "server" : "client");
+			if (!ssl->server)
+			{
+				const unsigned char* protocol = 0;
+				unsigned int len = 0;
+				SSL_get0_alpn_selected(ssl, &protocol, &len);
+				if (len != 0)
+				{
+					if (len == 3 && !memcmp(protocol, "adc", len))
+						m_proto = PROTO_ADC;
+					else if (len == 4 && !memcmp(protocol, "nmdc", len))
+						m_proto = PROTO_NMDC;
+					dcdebug("ALPN negotiated %.*s (%d)\n", len, protocol, m_proto);
+				}
+			}
+			
 			return true;
 		}
 		if (!waitWant(ret, millis))

--- a/client/Socket.h
+++ b/client/Socket.h
@@ -86,15 +86,24 @@ class Socket
 			TYPE_TCP = 0, // IPPROTO_TCP
 			TYPE_UDP = 1  // IPPROTO_UDP
 		};
+
+		enum Protocol
+		{
+			PROTO_DEFAULT = 0,
+			PROTO_NMDC = 1,
+			PROTO_ADC = 2
+		};
 		
 		Socket() : m_sock(INVALID_SOCKET), connected(false)
 			, m_maxSpeed(0), m_currentBucket(0) //[+] IRainman SpeedLimiter
 			, m_type(TYPE_TCP), port(0)
+			, m_proto(PROTO_DEFAULT)
 		{
 		}
 		Socket(const string& aIp, uint16_t aPort) : m_sock(INVALID_SOCKET), connected(false)
 			, m_maxSpeed(0), m_currentBucket(0) //[+] IRainman SpeedLimiter
 			, m_type(TYPE_TCP)
+			, m_proto(PROTO_DEFAULT)
 		{
 			connect(aIp, aPort);
 		}
@@ -272,6 +281,7 @@ class Socket
 		GETSET(uint16_t, port, Port);
 		
 		socket_t m_sock;
+		Protocol m_proto;
 		
 		//[+] IRainman SpeedLimiter
 		GETSET(int64_t, m_maxSpeed, MaxSpeed);


### PR DESCRIPTION
Implement initial support for ALPN.

The client will only advertise supported protocols for the server, but won't use the result of the negotiation yet.

Following changes should use `m_proto` on `Socket` to detect the protocol when using TLS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pavel-pimenov/flylinkdc-r5xx/1720)
<!-- Reviewable:end -->
